### PR TITLE
removing eval dates that aren't aligned with hub

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -168,8 +168,6 @@ eval_sets:
     - "2025-05-03"
     - "2025-05-10"
     - "2025-05-17"
-    - "2025-05-24"
-    - "2025-05-31"
 - eval_set_name: 2024-2025 season, US national level
   task_filters:
     location:
@@ -204,8 +202,6 @@ eval_sets:
     - "2025-05-03"
     - "2025-05-10"
     - "2025-05-17"
-    - "2025-05-24"
-    - "2025-05-31"
 - eval_set_name: 2023-2024 season, state level
   task_filters:
     location:
@@ -267,7 +263,6 @@ eval_sets:
     - 2
     - 3
     reference_date:
-    - "2023-10-14"
     - "2023-10-21"
     - "2023-10-28"
     - "2023-11-04" 
@@ -308,7 +303,6 @@ eval_sets:
     - 2
     - 3
     reference_date:
-    - "2023-10-14"
     - "2023-10-21"
     - "2023-10-28"
     - "2023-11-04" 


### PR DESCRIPTION
related to https://github.com/reichlab/forecast-sandbox-2025-2026/issues/21